### PR TITLE
EOL Fedora 34

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -117,20 +117,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    target-branch: fedora-34
-    open-pull-requests-limit: 10
-
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
-    target-branch: fedora-34
-    open-pull-requests-limit: 10
-
-  - package-ecosystem: docker
-    directory: /
-    schedule:
-      interval: weekly
     target-branch: fedora-35
     open-pull-requests-limit: 10
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The container is based on [LTS](https://en.wikipedia.org/wiki/Long-term_support)
 | Debian       | buster (10)    | AMD64, ARM64 | Supported   |
 | Debian       | bullseye (11)  | AMD64, ARM64 | Supported   |
 | Debian       | bookworm (12)  | AMD64, ARM64 | Development |
-| Fedora       | 34             | AMD64, ARM64 | Legacy      |
+| Fedora       | 34             | AMD64, ARM64 | End-of-Life |
 | Fedora       | 35             | AMD64, ARM64 | Legacy      |
 | Ubuntu       | bionic (18.04) | AMD64, ARM64 | Legacy      |
 | Ubuntu       | focal (20.04)  | AMD64, ARM64 | Supported   |


### PR DESCRIPTION
The Fedora Project ends support for version 34 on June 7th, 2022.

- [x] Update `.github/dependabot.yml`
- [x] Update `README.md`
- [ ] Delete package
- [ ] Create pull request for Fedora 35