### PR TITLE
Use default open issues limit for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,137 +6,117 @@ updates:
     schedule:
       interval: weekly
     target-branch: centos-7
-    open-pull-requests-limit: 10
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     target-branch: centos-7
-    open-pull-requests-limit: 10
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
     target-branch: master
-    open-pull-requests-limit: 10
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     target-branch: master
-    open-pull-requests-limit: 10
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
     target-branch: debian-buster
-    open-pull-requests-limit: 10
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     target-branch: debian-buster
-    open-pull-requests-limit: 10
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
     target-branch: debian-bullseye
-    open-pull-requests-limit: 10
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     target-branch: debian-bullseye
-    open-pull-requests-limit: 10
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
     target-branch: debian-bookworm
-    open-pull-requests-limit: 10
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     target-branch: debian-bookworm
-    open-pull-requests-limit: 10
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
     target-branch: ubuntu-bionic
-    open-pull-requests-limit: 10
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     target-branch: ubuntu-bionic
-    open-pull-requests-limit: 10
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
     target-branch: ubuntu-focal
-    open-pull-requests-limit: 10
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     target-branch: ubuntu-focal
-    open-pull-requests-limit: 10
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
     target-branch: ubuntu-jammy
-    open-pull-requests-limit: 10
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     target-branch: ubuntu-jammy
-    open-pull-requests-limit: 10
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
     target-branch: fedora-34
-    open-pull-requests-limit: 10
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     target-branch: fedora-34
-    open-pull-requests-limit: 10
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
     target-branch: fedora-35
-    open-pull-requests-limit: 10
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     target-branch: fedora-35
-    open-pull-requests-limit: 10


### PR DESCRIPTION
Switch back to the default behavior and reduce the load on GitHub Actions.