### PR TITLE
EOL Fedora 35

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -96,15 +96,3 @@ updates:
     schedule:
       interval: weekly
     target-branch: ubuntu-jammy
-
-  - package-ecosystem: docker
-    directory: /
-    schedule:
-      interval: weekly
-    target-branch: fedora-35
-
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
-    target-branch: fedora-35

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The container is based on [LTS](https://en.wikipedia.org/wiki/Long-term_support)
 | Debian       | bullseye (11)  | AMD64, ARM64 | Supported   |
 | Debian       | bookworm (12)  | AMD64, ARM64 | Development |
 | Fedora       | 34             | AMD64, ARM64 | End-of-Life |
-| Fedora       | 35             | AMD64, ARM64 | Legacy      |
+| Fedora       | 35             | AMD64, ARM64 | End-of-Life |
 | Ubuntu       | bionic (18.04) | AMD64, ARM64 | Legacy      |
 | Ubuntu       | focal (20.04)  | AMD64, ARM64 | Supported   |
 | Ubuntu       | jammy (22.04)  | AMD64, ARM64 | Supported   |


### PR DESCRIPTION
The Fedora Project ends support for version 35 on November 15th, 2022.

- [x] Update `.github/dependabot.yml`
- [x] Update `README.md`
- [ ] Delete package