### PR TITLE
Update Dockerfile images

### DIFF
--- a/Dockerfile.debian-10
+++ b/Dockerfile.debian-10
@@ -1,4 +1,4 @@
-FROM docker.io/debian:bullseye-20231218-slim
+FROM docker.io/debian:buster-20231218-slim
 
 LABEL org.opencontainers.image.description="Container for Molecule"
 LABEL org.opencontainers.image.source=https://github.com/hspaans/molecule-containers

--- a/Dockerfile.debian-11
+++ b/Dockerfile.debian-11
@@ -1,4 +1,4 @@
-FROM docker.io/debian:bullseye-20231218-slim
+FROM docker.io/debian:bookworm-20231218-slim
 
 LABEL org.opencontainers.image.description="Container for Molecule"
 LABEL org.opencontainers.image.source=https://github.com/hspaans/molecule-containers

--- a/Dockerfile.debian-12
+++ b/Dockerfile.debian-12
@@ -1,4 +1,4 @@
-FROM docker.io/debian:bullseye-20231218-slim
+FROM docker.io/debian:bookworm-20231030-slim
 
 LABEL org.opencontainers.image.description="Container for Molecule"
 LABEL org.opencontainers.image.source=https://github.com/hspaans/molecule-containers
@@ -21,6 +21,6 @@ ENV DEBIAN_FRONTEND=dialog
 # Make sure systemd doesn't start agettys on tty[1-6].
 RUN rm -f /lib/systemd/system/multi-user.target.wants/getty.target
 
-VOLUME ["/sys/fs/cgroup"]
+VOLUME ["/sys/fs/cgroup", "/tmp", "/run"]
 
 CMD ["/lib/systemd/systemd"]

--- a/Dockerfile.ubuntu-20.04
+++ b/Dockerfile.ubuntu-20.04
@@ -1,4 +1,4 @@
-FROM docker.io/debian:bullseye-20231218-slim
+FROM docker.io/ubuntu:focal-20231003
 
 LABEL org.opencontainers.image.description="Container for Molecule"
 LABEL org.opencontainers.image.source=https://github.com/hspaans/molecule-containers

--- a/Dockerfile.ubuntu-22.04
+++ b/Dockerfile.ubuntu-22.04
@@ -1,4 +1,4 @@
-FROM docker.io/debian:bullseye-20231218-slim
+FROM docker.io/ubuntu:jammy-20231128
 
 LABEL org.opencontainers.image.description="Container for Molecule"
 LABEL org.opencontainers.image.source=https://github.com/hspaans/molecule-containers
@@ -21,6 +21,6 @@ ENV DEBIAN_FRONTEND=dialog
 # Make sure systemd doesn't start agettys on tty[1-6].
 RUN rm -f /lib/systemd/system/multi-user.target.wants/getty.target
 
-VOLUME ["/sys/fs/cgroup"]
+VOLUME ["/sys/fs/cgroup", "/tmp", "/run"]
 
 CMD ["/lib/systemd/systemd"]


### PR DESCRIPTION
This pull request updates the Dockerfile images to use the latest versions of Debian and Ubuntu. The changes include updating the base images and installing necessary packages.