### PR TITLE
Update dependabot configuration and add container release workflow for Ubuntu 24.04 and Dockerfile for Molecule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,27 +11,33 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    groups:
-      GitHub-Actions:
-        patterns:
-          - "*"
     target-branch: centos-7
 
   - package-ecosystem: docker
+    target-branch: master
     directory: /
     schedule:
       interval: weekly
-    target-branch: master
+      day: saturday
+    groups:
+      Docker:
+        patterns:
+          - "*"
+    assignees:
+      - "hspaans"
 
   - package-ecosystem: github-actions
+    target-branch: master
     directory: /
     schedule:
       interval: weekly
+      day: saturday
     groups:
       GitHub-Actions:
         patterns:
           - "*"
-    target-branch: master
+    assignees:
+      - "hspaans"
 
   - package-ecosystem: docker
     directory: /
@@ -43,10 +49,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    groups:
-      GitHub-Actions:
-        patterns:
-          - "*"
     target-branch: debian-buster
 
   - package-ecosystem: docker

--- a/.github/workflows/container-release-ubuntu2404.yml
+++ b/.github/workflows/container-release-ubuntu2404.yml
@@ -1,0 +1,46 @@
+---
+name: Container Release (Ubuntu 24.04)
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'Dockerfile.ubuntu-24.04'
+      - '.github/workflows/container-release-ubuntu-24.04.yml'
+
+jobs:
+  build-release:
+    name: Build and Release
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+
+      - name: Login to Packages Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: false
+          file: Dockerfile.ubuntu-24.04
+          tags:
+            - ghcr.io/hspaans/molecule-container-ubuntu:24.04
+            - ghcr.io/hspaans/molecule-container-ubuntu:noble
+            - ghcr.io/hspaans/molecule-container-ubuntu:devel

--- a/Dockerfile.ubuntu-24.04
+++ b/Dockerfile.ubuntu-24.04
@@ -1,0 +1,26 @@
+FROM docker.io/ubuntu:noble-20231214
+
+LABEL org.opencontainers.image.description="Container for Molecule"
+LABEL org.opencontainers.image.source=https://github.com/hspaans/molecule-containers
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Configure apt and install packages
+# hadolint ignore=DL3008
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends systemd systemd-sysv python3 \
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog
+
+# Make sure systemd doesn't start agettys on tty[1-6].
+RUN rm -f /lib/systemd/system/multi-user.target.wants/getty.target
+
+VOLUME ["/sys/fs/cgroup", "/tmp", "/run"]
+
+CMD ["/lib/systemd/systemd"]


### PR DESCRIPTION
This pull request includes updates to the dependabot configuration and adds a container release workflow for Ubuntu 24.04 and a Dockerfile for Molecule.