### PR TITLE
Update tags in container-release-ubuntu2404.yml

### DIFF
--- a/.github/workflows/container-release-ubuntu2404.yml
+++ b/.github/workflows/container-release-ubuntu2404.yml
@@ -40,7 +40,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: false
           file: Dockerfile.ubuntu-24.04
-          tags:
-            - ghcr.io/hspaans/molecule-container-ubuntu:24.04
-            - ghcr.io/hspaans/molecule-container-ubuntu:noble
-            - ghcr.io/hspaans/molecule-container-ubuntu:devel
+          tags: |
+            ghcr.io/hspaans/molecule-container-ubuntu:24.04
+            ghcr.io/hspaans/molecule-container-ubuntu:noble
+            ghcr.io/hspaans/molecule-container-ubuntu:devel


### PR DESCRIPTION
This PR updates the tags in the container-release-ubuntu2404.yml file to include the latest versions of the molecule-container-ubuntu image: 24.04, noble, and devel.