### PR TITLE
Update container release tags

### DIFF
--- a/.github/workflows/container-release-debian-10.yml
+++ b/.github/workflows/container-release-debian-10.yml
@@ -57,4 +57,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           file: Dockerfile.debian-10
-          tags: ghcr.io/hspaans/molecule-containers:debian-10
+          tags: |
+            ghcr.io/hspaans/molecule-containers:debian-buster
+            ghcr.io/hspaans/molecule-containers:debian-10

--- a/.github/workflows/container-release-debian-11.yml
+++ b/.github/workflows/container-release-debian-11.yml
@@ -57,4 +57,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           file: Dockerfile.debian-11
-          tags: ghcr.io/hspaans/molecule-containers:debian-11
+          tags: |
+            ghcr.io/hspaans/molecule-containers:debian-bullseye
+            ghcr.io/hspaans/molecule-containers:debian-11

--- a/.github/workflows/container-release-debian-12.yml
+++ b/.github/workflows/container-release-debian-12.yml
@@ -57,4 +57,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           file: Dockerfile.debian-12
-          tags: ghcr.io/hspaans/molecule-containers:debian-12
+          tags: |
+            ghcr.io/hspaans/molecule-containers:debian-bookworm
+            ghcr.io/hspaans/molecule-containers:debian-12

--- a/.github/workflows/container-release-ubuntu-2004.yml
+++ b/.github/workflows/container-release-ubuntu-2004.yml
@@ -57,4 +57,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           file: Dockerfile.ubuntu-20.04
-          tags: ghcr.io/hspaans/molecule-containers:ubuntu-20.04
+          tags: |
+            ghcr.io/hspaans/molecule-containers:ubuntu-focal
+            ghcr.io/hspaans/molecule-containers:ubuntu-20.04

--- a/.github/workflows/container-release-ubuntu-2204.yml
+++ b/.github/workflows/container-release-ubuntu-2204.yml
@@ -57,4 +57,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           file: Dockerfile.ubuntu-22.04
-          tags: ghcr.io/hspaans/molecule-containers:ubuntu-22.04
+          tags: |
+            ghcr.io/hspaans/molecule-containers:ubuntu-jammy
+            ghcr.io/hspaans/molecule-containers:ubuntu-22.04

--- a/.github/workflows/container-release-ubuntu-2404.yml
+++ b/.github/workflows/container-release-ubuntu-2404.yml
@@ -57,4 +57,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           file: Dockerfile.ubuntu-24.04
-          tags: ghcr.io/hspaans/molecule-containers:ubuntu-24.04
+          tags: |
+            ghcr.io/hspaans/molecule-containers:ubuntu-noble
+            ghcr.io/hspaans/molecule-containers:ubuntu-24.04


### PR DESCRIPTION
This pull request updates the container release tags for the molecule-containers repository. It includes the following changes:

- Updated tags for Debian 10 to debian-buster and debian-10

- Updated tags for Debian 11 to debian-bullseye and debian-11

- Updated tags for Debian 12 to debian-bookworm and debian-12

- Updated tags for Ubuntu 20.04 to ubuntu-focal and ubuntu-20.04

- Updated tags for Ubuntu 22.04 to ubuntu-jammy and ubuntu-22.04

- Updated tags for Ubuntu 24.04 to ubuntu-noble and ubuntu-24.04