### PR TITLE
Add Dockerfile and workflow for container release (Amazon Linux 2023)

### DIFF
--- a/.github/workflows/container-release-amazonlinux-2023.yml
+++ b/.github/workflows/container-release-amazonlinux-2023.yml
@@ -1,0 +1,60 @@
+---
+name: Container Release (Amazon Linux 2023)
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "Dockerfile.amazonlinux-2023"
+      - ".github/workflows/container-release-amazonlinux-2023.yml"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "Dockerfile.amazonlinux-2023"
+      - ".github/workflows/container-release-amazonlinux-2023.yml"
+
+jobs:
+  build-test:
+    name: Container Test Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+
+      - name: Run tests
+        run: docker build . --file Dockerfile.amazonlinux-2023
+
+  build-release:
+    name: Container Release
+    runs-on: ubuntu-latest
+    needs: build-test
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Packages Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          file: Dockerfile.amazonlinux-2023
+          tags: ghcr.io/hspaans/molecule-containers:amazonlinux-2023

--- a/Dockerfile.amazonlinux-2023
+++ b/Dockerfile.amazonlinux-2023
@@ -1,0 +1,17 @@
+FROM docker.io/amazonlinux:2023.3.20240108.0
+
+LABEL org.opencontainers.image.description="Fedora container for Molecule"
+LABEL org.opencontainers.image.source=https://github.com/hspaans/molecule-containers
+
+# Configure apt and install packages
+# hadolint ignore=DL3033
+RUN yum -y install systemd systemd-sysv python3 \
+    # Clean up
+    && yum clean all
+
+# Make sure systemd doesn't start agettys on tty[1-6].
+RUN rm -f /lib/systemd/system/multi-user.target.wants/getty.target
+
+VOLUME ["/sys/fs/cgroup"]
+
+CMD ["/lib/systemd/systemd"]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ For testing [Ansible][ansible] roles with [Molecule][molecule], it is useful to 
 Distributions are based on [LTS](https://en.wikipedia.org/wiki/Long-term_support) versions with official support and fall within N and N-1. Older images are removed from the registry when they reach end-of-life.
 
 Currently, the following distributions are supported:
+* Amazon Linux 2023 - `ghcr.io/hspaans/molecule-containers:amazonlinux-2023`
 * Debian 10 (buster) - `ghcr.io/hspaans/molecule-containers:debian-10`
 * Debian 11 (bullseye) - `ghcr.io/hspaans/molecule-containers:debian-11`
 * Debian 12 (bookworm) - `ghcr.io/hspaans/molecule-containers:debian-12`


### PR DESCRIPTION
This pull request adds a Dockerfile and workflow for container release of Amazon Linux 2023. The Dockerfile installs systemd, python3, and other necessary packages, and the workflow builds and pushes the container to the GitHub Container Registry.