### PR TITLE
Update container release workflows for Oracle Linux 7, 8, and 9

### DIFF
--- a/.github/workflows/container-release-oraclelinux-7.yml
+++ b/.github/workflows/container-release-oraclelinux-7.yml
@@ -1,0 +1,60 @@
+---
+name: Container Release (Oracle Linux 7)
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "Dockerfile.oraclelinux-7"
+      - ".github/workflows/container-release-oraclelinux-7.yml"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "Dockerfile.oraclelinux-7"
+      - ".github/workflows/container-release-oraclelinux-7.yml"
+
+jobs:
+  build-test:
+    name: Container Test Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+
+      - name: Run tests
+        run: docker build . --file Dockerfile.oraclelinux-7
+
+  build-release:
+    name: Container Release
+    runs-on: ubuntu-latest
+    needs: build-test
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Packages Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          file: Dockerfile.oraclelinux-7
+          tags: ghcr.io/hspaans/molecule-containers:oraclelinux-7

--- a/.github/workflows/container-release-oraclelinux-8.yml
+++ b/.github/workflows/container-release-oraclelinux-8.yml
@@ -1,0 +1,60 @@
+---
+name: Container Release (Oracle Linux 7)
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "Dockerfile.oraclelinux-8"
+      - ".github/workflows/container-release-oraclelinux-8.yml"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "Dockerfile.oraclelinux-8"
+      - ".github/workflows/container-release-oraclelinux-8.yml"
+
+jobs:
+  build-test:
+    name: Container Test Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+
+      - name: Run tests
+        run: docker build . --file Dockerfile.oraclelinux-8
+
+  build-release:
+    name: Container Release
+    runs-on: ubuntu-latest
+    needs: build-test
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Packages Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          file: Dockerfile.oraclelinux-8
+          tags: ghcr.io/hspaans/molecule-containers:oraclelinux-8

--- a/.github/workflows/container-release-oraclelinux-8.yml
+++ b/.github/workflows/container-release-oraclelinux-8.yml
@@ -1,5 +1,5 @@
 ---
-name: Container Release (Oracle Linux 7)
+name: Container Release (Oracle Linux 8)
 
 on:
   push:

--- a/.github/workflows/container-release-oraclelinux-9.yml
+++ b/.github/workflows/container-release-oraclelinux-9.yml
@@ -1,5 +1,5 @@
 ---
-name: Container Release (Oracle Linux 7)
+name: Container Release (Oracle Linux 9)
 
 on:
   push:

--- a/.github/workflows/container-release-oraclelinux-9.yml
+++ b/.github/workflows/container-release-oraclelinux-9.yml
@@ -1,0 +1,60 @@
+---
+name: Container Release (Oracle Linux 7)
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "Dockerfile.oraclelinux-9"
+      - ".github/workflows/container-release-oraclelinux-9.yml"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "Dockerfile.oraclelinux-9"
+      - ".github/workflows/container-release-oraclelinux-9.yml"
+
+jobs:
+  build-test:
+    name: Container Test Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+
+      - name: Run tests
+        run: docker build . --file Dockerfile.oraclelinux-9
+
+  build-release:
+    name: Container Release
+    runs-on: ubuntu-latest
+    needs: build-test
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Packages Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          file: Dockerfile.oraclelinux-9
+          tags: ghcr.io/hspaans/molecule-containers:oraclelinux-9

--- a/Dockerfile.amazonlinux-2023
+++ b/Dockerfile.amazonlinux-2023
@@ -1,6 +1,6 @@
 FROM docker.io/amazonlinux:2023.3.20240108.0
 
-LABEL org.opencontainers.image.description="Fedora container for Molecule"
+LABEL org.opencontainers.image.description="Amazon Linux 2023 container for Molecule"
 LABEL org.opencontainers.image.source=https://github.com/hspaans/molecule-containers
 
 # Configure apt and install packages

--- a/Dockerfile.oraclelinux-7
+++ b/Dockerfile.oraclelinux-7
@@ -1,0 +1,17 @@
+FROM docker.io/oraclelinux:7.9
+
+LABEL org.opencontainers.image.description="Oracle Linux 7 container for Molecule"
+LABEL org.opencontainers.image.source=https://github.com/hspaans/molecule-containers
+
+# Configure apt and install packages
+# hadolint ignore=DL3033
+RUN yum -y install systemd systemd-sysv python3 \
+    # Clean up
+    && yum clean all
+
+# Make sure systemd doesn't start agettys on tty[1-6].
+RUN rm -f /lib/systemd/system/multi-user.target.wants/getty.target
+
+VOLUME ["/sys/fs/cgroup"]
+
+CMD ["/lib/systemd/systemd"]

--- a/Dockerfile.oraclelinux-8
+++ b/Dockerfile.oraclelinux-8
@@ -1,0 +1,17 @@
+FROM docker.io/oraclelinux:8.9
+
+LABEL org.opencontainers.image.description="Oracle Linux 8 container for Molecule"
+LABEL org.opencontainers.image.source=https://github.com/hspaans/molecule-containers
+
+# Configure apt and install packages
+# hadolint ignore=DL3033
+RUN yum -y install systemd systemd-sysv python3 \
+    # Clean up
+    && yum clean all
+
+# Make sure systemd doesn't start agettys on tty[1-6].
+RUN rm -f /lib/systemd/system/multi-user.target.wants/getty.target
+
+VOLUME ["/sys/fs/cgroup"]
+
+CMD ["/lib/systemd/systemd"]

--- a/Dockerfile.oraclelinux-9
+++ b/Dockerfile.oraclelinux-9
@@ -1,0 +1,17 @@
+FROM docker.io/oraclelinux:9
+
+LABEL org.opencontainers.image.description="Oracle Linux 9 container for Molecule"
+LABEL org.opencontainers.image.source=https://github.com/hspaans/molecule-containers
+
+# Configure apt and install packages
+# hadolint ignore=DL3033
+RUN yum -y install systemd systemd-sysv python3 \
+    # Clean up
+    && yum clean all
+
+# Make sure systemd doesn't start agettys on tty[1-6].
+RUN rm -f /lib/systemd/system/multi-user.target.wants/getty.target
+
+VOLUME ["/sys/fs/cgroup"]
+
+CMD ["/lib/systemd/systemd"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Currently, the following distributions are supported:
 * Debian 12 (bookworm) - `ghcr.io/hspaans/molecule-containers:debian-12`
 * Fedora 38 - `ghcr.io/hspaans/molecule-containers:fedora-38`
 * Fedora 39 - `ghcr.io/hspaans/molecule-containers:fedora-39`
+* Oracle Linux 8 - `ghcr.io/hspaans/molecule-containers:oraclelinux-8`
+* Oracle Linux 9 - `ghcr.io/hspaans/molecule-containers:oraclelinux-9`
 * Ubuntu 20.04 (focal) - `ghcr.io/hspaans/molecule-containers:ubuntu-20.04`
 * Ubuntu 22.04 (jammy) - `ghcr.io/hspaans/molecule-containers:ubuntu-22.04`
 * Ubuntu 24.04 (noble) - `ghcr.io/hspaans/molecule-containers:ubuntu-24.04`


### PR DESCRIPTION
This pull request updates the container release workflows for Oracle Linux 7, 8, and 9. It adds new Dockerfiles and workflows for each version, allowing for container builds and releases for these specific Oracle Linux versions.