### PR TITLE
Add Dockerfiles and workflows for Rocky Linux 8 and 9

### DIFF
--- a/.github/workflows/container-release-rockylinux-8.yml
+++ b/.github/workflows/container-release-rockylinux-8.yml
@@ -1,0 +1,60 @@
+---
+name: Container Release (Rocky Linux 8)
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "Dockerfile.rockylinux-8"
+      - ".github/workflows/container-release-rockylinux-8.yml"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "Dockerfile.rockylinux-8"
+      - ".github/workflows/container-release-rockylinux-8.yml"
+
+jobs:
+  build-test:
+    name: Container Test Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+
+      - name: Run tests
+        run: docker build . --file Dockerfile.rockylinux-8
+
+  build-release:
+    name: Container Release
+    runs-on: ubuntu-latest
+    needs: build-test
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Packages Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          file: Dockerfile.rockylinux-8
+          tags: ghcr.io/hspaans/molecule-containers:rockylinux-8

--- a/.github/workflows/container-release-rockylinux-9.yml
+++ b/.github/workflows/container-release-rockylinux-9.yml
@@ -1,0 +1,60 @@
+---
+name: Container Release (Rocky Linux 9)
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "Dockerfile.rockylinux-9"
+      - ".github/workflows/container-release-rockylinux-9.yml"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "Dockerfile.rockylinux-9"
+      - ".github/workflows/container-release-rockylinux-9.yml"
+
+jobs:
+  build-test:
+    name: Container Test Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+
+      - name: Run tests
+        run: docker build . --file Dockerfile.rockylinux-9
+
+  build-release:
+    name: Container Release
+    runs-on: ubuntu-latest
+    needs: build-test
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Packages Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          file: Dockerfile.rockylinux-9
+          tags: ghcr.io/hspaans/molecule-containers:rockylinux-9

--- a/Dockerfile.rockylinux-8
+++ b/Dockerfile.rockylinux-8
@@ -1,0 +1,17 @@
+FROM docker.io/rockylinux:8.9.20231119
+
+LABEL org.opencontainers.image.description="Rocky Linux 8 container for Molecule"
+LABEL org.opencontainers.image.source=https://github.com/hspaans/molecule-containers
+
+# Configure apt and install packages
+# hadolint ignore=DL3033
+RUN yum -y install systemd systemd-sysv python3 \
+    # Clean up
+    && yum clean all
+
+# Make sure systemd doesn't start agettys on tty[1-6].
+RUN rm -f /lib/systemd/system/multi-user.target.wants/getty.target
+
+VOLUME ["/sys/fs/cgroup"]
+
+CMD ["/lib/systemd/systemd"]

--- a/Dockerfile.rockylinux-9
+++ b/Dockerfile.rockylinux-9
@@ -1,0 +1,17 @@
+FROM docker.io/rockylinux:9.3.20231119
+
+LABEL org.opencontainers.image.description="Rocky Linux 9 container for Molecule"
+LABEL org.opencontainers.image.source=https://github.com/hspaans/molecule-containers
+
+# Configure apt and install packages
+# hadolint ignore=DL3033
+RUN yum -y install systemd systemd-sysv python3 \
+    # Clean up
+    && yum clean all
+
+# Make sure systemd doesn't start agettys on tty[1-6].
+RUN rm -f /lib/systemd/system/multi-user.target.wants/getty.target
+
+VOLUME ["/sys/fs/cgroup"]
+
+CMD ["/lib/systemd/systemd"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Currently, the following distributions are supported:
 * Fedora 39 - `ghcr.io/hspaans/molecule-containers:fedora-39`
 * Oracle Linux 8 - `ghcr.io/hspaans/molecule-containers:oraclelinux-8`
 * Oracle Linux 9 - `ghcr.io/hspaans/molecule-containers:oraclelinux-9`
+* Rocky Linux 8 - `ghcr.io/hspaans/molecule-containers:rockylinux-8`
+* Rocky Linux 9 - `ghcr.io/hspaans/molecule-containers:rockylinux-9`
 * Ubuntu 20.04 (focal) - `ghcr.io/hspaans/molecule-containers:ubuntu-20.04`
 * Ubuntu 22.04 (jammy) - `ghcr.io/hspaans/molecule-containers:ubuntu-22.04`
 * Ubuntu 24.04 (noble) - `ghcr.io/hspaans/molecule-containers:ubuntu-24.04`


### PR DESCRIPTION
This pull request adds Dockerfiles and workflows for building and releasing containers for Rocky Linux 8 and 9. The Dockerfiles include the necessary configurations and packages for running Molecule. The workflows automate the build and release process for the containers.