### PR TITLE
Add Dockerfile and GitHub workflow for Fedora 40 container release

### DIFF
--- a/.github/workflows/container-release-fedora-40.yml
+++ b/.github/workflows/container-release-fedora-40.yml
@@ -1,0 +1,60 @@
+---
+name: Container Release (Fedora 40)
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "Dockerfile.fedora-40"
+      - ".github/workflows/container-release-fedora-40.yml"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "Dockerfile.fedora-40"
+      - ".github/workflows/container-release-fedora-40.yml"
+
+jobs:
+  build-test:
+    name: Container Test Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+
+      - name: Run tests
+        run: docker build . --file Dockerfile.fedora-40
+
+  build-release:
+    name: Container Release
+    runs-on: ubuntu-latest
+    needs: build-test
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Packages Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          file: Dockerfile.fedora-40
+          tags: ghcr.io/hspaans/molecule-containers:fedora-40

--- a/Dockerfile.fedora-40
+++ b/Dockerfile.fedora-40
@@ -1,0 +1,17 @@
+FROM docker.io/fedora:40
+
+LABEL org.opencontainers.image.description="Fedora container for Molecule"
+LABEL org.opencontainers.image.source=https://github.com/hspaans/molecule-containers
+
+# Configure apt and install packages
+# hadolint ignore=DL3033
+RUN yum -y install systemd systemd-sysv python3 \
+    # Clean up
+    && yum clean all
+
+# Make sure systemd doesn't start agettys on tty[1-6].
+RUN rm -f /lib/systemd/system/multi-user.target.wants/getty.target
+
+VOLUME ["/sys/fs/cgroup"]
+
+CMD ["/lib/systemd/systemd"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Currently, the following distributions are supported:
 * Debian 12 (bookworm) - `ghcr.io/hspaans/molecule-containers:debian-12`
 * Fedora 38 - `ghcr.io/hspaans/molecule-containers:fedora-38`
 * Fedora 39 - `ghcr.io/hspaans/molecule-containers:fedora-39`
+* Fedora 40 - `ghcr.io/hspaans/molecule-containers:fedora-40`
 * Oracle Linux 8 - `ghcr.io/hspaans/molecule-containers:oraclelinux-8`
 * Oracle Linux 9 - `ghcr.io/hspaans/molecule-containers:oraclelinux-9`
 * Rocky Linux 8 - `ghcr.io/hspaans/molecule-containers:rockylinux-8`


### PR DESCRIPTION
This pull request adds a Dockerfile and a GitHub workflow for the Fedora 40 container release. The Dockerfile installs systemd, python3, and other necessary packages, and the GitHub workflow builds and pushes the container image to the GitHub Container Registry. This addition expands the supported distributions for the Molecule project.