### PR TITLE
Add Dockerfile and GitHub workflow for Alpine 3.20 container release

### DIFF
--- a/.github/workflows/container-release-alpine-3.20.yml
+++ b/.github/workflows/container-release-alpine-3.20.yml
@@ -1,0 +1,60 @@
+---
+name: Container Release (Alpine 3.20)
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "Dockerfile.alpine-3.20"
+      - ".github/workflows/container-release-alpine-3.20.yml"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "Dockerfile.alpine-3.20"
+      - ".github/workflows/container-release-alpine-3.20.yml"
+
+jobs:
+  build-test:
+    name: Container Test Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+
+      - name: Run tests
+        run: docker build . --file Dockerfile.alpine-3.20
+
+  build-release:
+    name: Container Release
+    runs-on: ubuntu-latest
+    needs: build-test
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Packages Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          file: Dockerfile.alpine-3.20
+          tags: ghcr.io/hspaans/molecule-containers:alpine-3.20

--- a/Dockerfile.alpine-3.20
+++ b/Dockerfile.alpine-3.20
@@ -1,0 +1,12 @@
+FROM docker.io/alpine:3.20.0
+
+LABEL org.opencontainers.image.description="Alpine container for Molecule"
+LABEL org.opencontainers.image.source=https://github.com/hspaans/molecule-containers
+
+# Configure apt and install packages
+# hadolint ignore=DL3033
+RUN apk --no-cache add python3 \
+    # Clean up
+    && apk cache clean
+
+CMD ["/sbin/init"]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Currently, the following distributions are supported:
 Experimental images are available for the following distributions:
 * Alpine 3.18 - `ghcr.io/hspaans/molecule-containers:alpine-3.18`
 * Alpine 3.19 - `ghcr.io/hspaans/molecule-containers:alpine-3.19`
+* Alpine 3.20 - `ghcr.io/hspaans/molecule-containers:alpine-3.20`
 
 > **Note:** Previous images were stored in the `hspaans/molecule-container-<distribution>:<version>` package repository on GitHube. These images are no longer maintained and will be removed in the future as they become end-of-life. It is recommended to use the new images from the `ghcr.io/hspaans/molecule-containers:<distribution>-<version>` package repository.
 


### PR DESCRIPTION
This pull request adds a Dockerfile and a GitHub workflow for the release of a container based on Alpine 3.20. The Dockerfile installs Python3 and the workflow builds and pushes the container to the GitHub Container Registry.