### PR TITLE
Bump Alpine versions in Dockerfiles to latest releases

### DIFF
--- a/Dockerfile.alpine-3.18
+++ b/Dockerfile.alpine-3.18
@@ -1,4 +1,4 @@
-FROM docker.io/alpine:3.18.9
+FROM docker.io/alpine:3.18.11
 
 LABEL org.opencontainers.image.description="Alpine container for Molecule"
 LABEL org.opencontainers.image.source=https://github.com/hspaans/molecule-containers

--- a/Dockerfile.alpine-3.19
+++ b/Dockerfile.alpine-3.19
@@ -1,4 +1,4 @@
-FROM docker.io/alpine:3.19.4
+FROM docker.io/alpine:3.19.6
 
 LABEL org.opencontainers.image.description="Alpine container for Molecule"
 LABEL org.opencontainers.image.source=https://github.com/hspaans/molecule-containers

--- a/Dockerfile.alpine-3.20
+++ b/Dockerfile.alpine-3.20
@@ -1,4 +1,4 @@
-FROM docker.io/alpine:3.20.3
+FROM docker.io/alpine:3.20.5
 
 LABEL org.opencontainers.image.description="Alpine container for Molecule"
 LABEL org.opencontainers.image.source=https://github.com/hspaans/molecule-containers

--- a/Dockerfile.alpine-3.21
+++ b/Dockerfile.alpine-3.21
@@ -1,4 +1,4 @@
-FROM docker.io/alpine:3.21.0
+FROM docker.io/alpine:3.21.2
 
 LABEL org.opencontainers.image.description="Alpine container for Molecule"
 LABEL org.opencontainers.image.source=https://github.com/hspaans/molecule-containers


### PR DESCRIPTION
Update Dockerfiles to use the latest Alpine versions for improved security and performance.