### PR TITLE
Update Docker base image to Debian Bookworm

### DIFF
--- a/.github/workflows/container-release-debian-12.yml
+++ b/.github/workflows/container-release-debian-12.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   build-test:
     name: Container Test Build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout the code
@@ -29,7 +29,7 @@ jobs:
 
   build-release:
     name: Container Release
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: build-test
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
 

--- a/Dockerfile.debian-12
+++ b/Dockerfile.debian-12
@@ -1,4 +1,4 @@
-FROM docker.io/debian:12.6-slim
+FROM docker.io/debian:bookworm-20250407-slim
 
 LABEL org.opencontainers.image.description="Container for Molecule"
 LABEL org.opencontainers.image.source=https://github.com/hspaans/molecule-containers


### PR DESCRIPTION
Switch the base image in the Dockerfile to the latest Debian Bookworm version for improved compatibility and features.