### PR TITLE
Update Dependabot configuration and auto-merge strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,6 @@
 version: 2
 updates:
   - package-ecosystem: docker
-    target-branch: master
     directory: /
     schedule:
       interval: daily
@@ -10,8 +9,6 @@ updates:
       - dependency-name: "alpine"
         update-types: ["version-update:semver-major","version-update:semver-minor"]
       - dependency-name: "amazonlinux"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "debian"
         update-types: ["version-update:semver-major"]
       - dependency-name: "fedora"
         update-types: ["version-update:semver-major"]
@@ -21,7 +18,6 @@ updates:
         update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
-    target-branch: master
     directory: /
     schedule:
       interval: monthly

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -20,7 +20,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
         if: contains(steps.metadata.outputs.package-ecosystem, 'docker') && steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Remove target-branch specification and obsolete dependency for Debian in the Dependabot configuration. Change the auto-merge strategy for Dependabot PRs to use squash instead of merge.