### PR TITLE
Enhance auto-merge conditions for Dependabot PRs to include Debian updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,7 +19,12 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
-        if: contains(steps.metadata.outputs.package-ecosystem, 'docker') && steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        if: |
+          contains(steps.metadata.outputs.package-ecosystem, 'docker') &&
+          (
+            steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+            contains(steps.metadata.outputs.dependency-names, 'debian')
+          )
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
Update the auto-merge conditions to allow Debian updates alongside existing Docker version updates.