### PR TITLE
Enhance auto-merge conditions for Dependabot PRs to include Ubuntu updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -23,7 +23,8 @@ jobs:
           contains(steps.metadata.outputs.package-ecosystem, 'docker') &&
           (
             steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-            contains(steps.metadata.outputs.dependency-names, 'debian')
+            contains(steps.metadata.outputs.dependency-names, 'debian') ||
+            contains(steps.metadata.outputs.dependency-names, 'ubuntu')
           )
         run: gh pr merge --auto --squash "$PR_URL"
         env:


### PR DESCRIPTION
Update auto-merge logic to allow Ubuntu updates alongside existing conditions for Dependabot pull requests.